### PR TITLE
add metadata view_only

### DIFF
--- a/src/pipelines_push_action/main.py
+++ b/src/pipelines_push_action/main.py
@@ -90,6 +90,7 @@ def update_pipelines(to_update, client: GlassFlowClient) -> None:
             source_kind=gf_pipeline.source_kind,
             source_config=gf_pipeline.source_config,
             env_vars=gf_pipeline.env_vars,
+            metadata={"view_only": True},
         )
         log.info(f"Updated pipeline {gf_pipeline.id}")
 

--- a/src/pipelines_push_action/yaml_utils.py
+++ b/src/pipelines_push_action/yaml_utils.py
@@ -126,6 +126,7 @@ def yaml_file_to_pipeline(
         sink_config=sink.config,
         source_kind=source.kind,
         source_config=source.config,
+        metadata={"view_only": True},
     )
 
 


### PR DESCRIPTION
Add metadata `{"view_only": True}` to pipelines created / updated by CI/CD so FE can block them from being modified in the webapp